### PR TITLE
Resume polish: density, Celestia/Palantir sub-roles, refreshed PRs

### DIFF
--- a/docs/superpowers/plans/2026-05-16-resume-density-and-celestia-consolidation.md
+++ b/docs/superpowers/plans/2026-05-16-resume-density-and-celestia-consolidation.md
@@ -1,0 +1,318 @@
+# Resume Density & Celestia Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce visual squish in the printed resume PDF and collapse three repeated Celestia entries into one consolidated block with sub-roles, while staying on a single letter-size page.
+
+**Architecture:** Single-file change to `public/resume.html` (a self-contained static HTML/CSS document with inline `<style>`). Three independent edit clusters: (1) tweak four existing CSS properties for density, (2) add new `.sub-role` / `.sub-date` CSS rules plus replace the three Celestia `<div class="role">` blocks with one consolidated block, (3) verify the printed PDF and optionally trim one bullet if the page overflows. No test harness exists for static resume rendering — verification is visual inspection in a browser at `/resume.html`.
+
+**Tech Stack:** Static HTML5 + inline CSS, served by Next.js 14 from `public/`. Local dev via `yarn dev`. No build step or test framework involved for this file.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-16-resume-density-and-celestia-consolidation-design.md`
+
+---
+
+## File Structure
+
+**Modified:**
+- `public/resume.html` — only file touched by this plan
+
+**Not touched:** `pages/`, `styles/`, `next.config.js` (resume is fully self-contained in the static file)
+
+---
+
+## Task 1: CSS density tweaks
+
+Goal: add vertical breathing room to bullets and sections without touching page margins.
+
+**Files:**
+- Modify: `public/resume.html` (the inline `<style>` block, specifically the `.role li { ... }` and `section { ... }` rules around lines 185–273 of the current file)
+
+- [ ] **Step 1: Start the dev server in the background**
+
+Run:
+```bash
+yarn dev
+```
+(Run in background. Default URL is `http://localhost:3000`. The resume is served from `http://localhost:3000/resume.html`.)
+
+Expected: Next.js starts and prints `Ready` once compiled.
+
+- [ ] **Step 2: Open the resume in a browser and capture the "before" state**
+
+Open `http://localhost:3000/resume.html`. Use the toolbar's "Print / Save as PDF" button and save a PDF aside for visual comparison. (Optional but useful — you'll want it for Task 3 verification.)
+
+- [ ] **Step 3: Edit `.role li` font-size, line-height, and margin-bottom**
+
+In `public/resume.html`, locate the `.role li { ... }` rule (currently around line 257) and change three properties.
+
+Use Edit on the `.role li` block:
+
+```css
+  .role li {
+    position: relative;
+    padding-left: 14px;
+    margin-bottom: 3px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--ink-soft);
+  }
+```
+
+becomes:
+
+```css
+  .role li {
+    position: relative;
+    padding-left: 14px;
+    margin-bottom: 6px;
+    font-size: 13.5px;
+    line-height: 1.55;
+    color: var(--ink-soft);
+  }
+```
+
+- [ ] **Step 4: Edit `section` margin-top**
+
+Locate `section { margin-top: 22px; }` (currently around line 185) and change it to:
+
+```css
+  section {
+    margin-top: 26px;
+  }
+```
+
+- [ ] **Step 5: Reload the browser and visually verify density change**
+
+Reload `http://localhost:3000/resume.html`. Expected: bullets visibly have more space between them, sections feel more separated. The page should still render cleanly with no broken layout. Old three-Celestia structure is still in place — that's expected at this stage.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add public/resume.html
+git commit -m "Add vertical breathing room to resume bullets and sections"
+```
+
+---
+
+## Task 2: Celestia consolidation (CSS + HTML in one atomic change)
+
+Goal: collapse the three Celestia `.role` blocks into one block with three italic sub-role labels, using refreshed PR counts and tightened EM/SWE wording. CSS and HTML are committed together because the new HTML references the new CSS classes.
+
+**Files:**
+- Modify: `public/resume.html`
+  - Inline `<style>` block: add new `.sub-role` and `.sub-role .sub-date` rules immediately after the `.role li::before` rule (currently ends around line 273)
+  - Body: replace the three Celestia `<div class="role">` blocks (currently lines 424–466) with one consolidated block
+
+- [ ] **Step 1: Add the new CSS rules**
+
+In `public/resume.html`, locate the `.role li::before { ... }` rule and the closing `}` that follows it. Add this block immediately after that closing brace (and before the `.role li a, .summary a { ... }` rule that follows):
+
+```css
+  .sub-role {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 13.5px;
+    color: var(--ink-soft);
+    margin: 10px 0 4px;
+  }
+  .role .sub-role:first-of-type {
+    margin-top: 6px;
+  }
+  .sub-role .sub-date {
+    font-family: var(--mono);
+    font-style: normal;
+    font-size: 10.5px;
+    color: var(--ink-muted);
+    margin-left: 2px;
+  }
+```
+
+- [ ] **Step 2: Replace the three Celestia `.role` blocks with one consolidated block**
+
+In `public/resume.html`, delete the three existing Celestia role blocks (the three consecutive `<div class="role">` blocks starting with `<span class="company">Celestia</span>` — currently lines 424–466 inclusive) and replace them with this single block.
+
+The exact old content to remove (use a multi-line Edit, anchored on the first opening `<div class="role">` after the `<h2 class="section-title">` and ending with the third `</div>` that closes the SWE block):
+
+```html
+      <div class="role">
+        <div class="role-head">
+          <div class="role-title">
+            <span class="company">Celestia</span>
+            <span class="sep">—</span>
+            <span class="position">Engineering Manager</span>
+          </div>
+          <div class="role-date">Mar 2026 — Present</div>
+        </div>
+        <ul>
+          <li>Lead an 8-person team (10 reports including two on loan to adjacent team) owning reliability, performance, and scale for the Celestia protocol</li>
+          <li>Defined and now drive execution against Q2 OKRs spanning network reliability, protocol performance, and scale targets</li>
+        </ul>
+      </div>
+
+      <div class="role">
+        <div class="role-head">
+          <div class="role-title">
+            <span class="company">Celestia</span>
+            <span class="sep">—</span>
+            <span class="position">Team Lead</span>
+          </div>
+          <div class="role-date">Dec 2025 — Mar 2026</div>
+        </div>
+        <ul>
+          <li>Led a 4-person team owning the Celestia consensus layer</li>
+        </ul>
+      </div>
+
+      <div class="role">
+        <div class="role-head">
+          <div class="role-title">
+            <span class="company">Celestia</span>
+            <span class="sep">—</span>
+            <span class="position">Senior Software Engineer</span>
+          </div>
+          <div class="role-date">Jul 2022 — Dec 2025</div>
+        </div>
+        <ul>
+          <li>Led the first consensus layer upgrade (v2.0.0), establishing the upgrade framework used by all subsequent network upgrades</li>
+          <li>Authored 888 and reviewed 1,956 merged pull requests across celestia-app and celestia-core</li>
+        </ul>
+      </div>
+```
+
+Replace with:
+
+```html
+      <div class="role">
+        <div class="role-head">
+          <div class="role-title">
+            <span class="company">Celestia</span>
+          </div>
+          <div class="role-date">Jul 2022 — Present</div>
+        </div>
+
+        <div class="sub-role">Engineering Manager <span class="sub-date">· Mar 2026 — Present</span></div>
+        <ul>
+          <li>Lead an 8-person team owning reliability, performance, and scale for the Celestia protocol</li>
+          <li>Set and drive Q2 OKRs across network reliability, protocol performance, and scale</li>
+        </ul>
+
+        <div class="sub-role">Team Lead <span class="sub-date">· Dec 2025 — Mar 2026</span></div>
+        <ul>
+          <li>Led a 4-person team owning the Celestia consensus layer</li>
+        </ul>
+
+        <div class="sub-role">Senior Software Engineer <span class="sub-date">· Jul 2022 — Dec 2025</span></div>
+        <ul>
+          <li>Led Celestia's first consensus-breaking upgrade (v2.0.0), establishing the framework reused by every subsequent network upgrade</li>
+          <li>Authored 1,168 and reviewed 2,427 merged pull requests across celestia-app and celestia-core</li>
+        </ul>
+      </div>
+```
+
+Note the changes embedded in the replacement:
+- Three separate `Celestia — Position` headers collapse to one `Celestia` header with overall date `Jul 2022 — Present`.
+- New `<div class="sub-role">` lines carry the position and date for each sub-role.
+- EM bullet 1: drops the "(10 reports including two on loan to adjacent team)" parenthetical.
+- EM bullet 2: "Defined and now drive execution against Q2 OKRs spanning ... targets" → "Set and drive Q2 OKRs across network reliability, protocol performance, and scale".
+- Team Lead bullet: unchanged.
+- SWE bullet 1: "Led the first consensus layer upgrade (v2.0.0), establishing the upgrade framework used by all subsequent network upgrades" → "Led Celestia's first consensus-breaking upgrade (v2.0.0), establishing the framework reused by every subsequent network upgrade".
+- SWE bullet 2: PR counts updated from `888 / 1,956` to `1,168 / 2,427`.
+
+- [ ] **Step 3: Reload the browser and verify the consolidated Celestia section**
+
+Reload `http://localhost:3000/resume.html`. Verify:
+- One "Celestia" header line, not three.
+- Three italic sub-role labels ("Engineering Manager · Mar 2026 — Present", "Team Lead · ...", "Senior Software Engineer · ...") nested under the Celestia header, each followed by its bullets.
+- EM bullet count is 2 (no parenthetical). Team Lead has 1 bullet. SWE has 2 bullets with refreshed numbers.
+- No broken layout, no missing styles. The sub-role lines should read as italic serif, with a mono-font date suffix.
+
+- [ ] **Step 4: Print to PDF and verify single-page fit**
+
+In the browser, click the "Print / Save as PDF" toolbar button. In the print dialog, choose "Save as PDF" with Letter paper size. Save to a temp location (e.g. `/tmp/resume-after.pdf`) and open it.
+
+Verify:
+- Content fits on exactly one page (no second page with overflow content).
+- Top, bottom, left, right margins look clean (no clipped content).
+- Bullets feel less squished than the "before" PDF from Task 1 Step 2.
+
+If the page overflows by one or more lines, proceed to Task 3. If it fits on one page, **skip Task 3 entirely**.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/resume.html
+git commit -m "Consolidate Celestia roles into single block with sub-roles
+
+Collapses three repeated Celestia entries into one company block
+with three italic sub-role labels. Refreshes PR counts (1,168 /
+2,427) and tightens EM and SWE bullet wording."
+```
+
+---
+
+## Task 3: Apply overflow escape valve (CONDITIONAL — only if Task 2 Step 4 showed overflow)
+
+Goal: trim the single weakest bullet on the resume to keep it on one page.
+
+**Files:**
+- Modify: `public/resume.html` (the AWS role's bullet list, currently around lines 478–481)
+
+- [ ] **Step 1: Confirm overflow exists**
+
+If the PDF from Task 2 Step 4 fit on one page, **stop — do not execute this task**.
+
+- [ ] **Step 2: Remove the "employee of the month" bullet**
+
+In `public/resume.html`, locate the AWS role's `<ul>` and remove this `<li>`:
+
+```html
+          <li>Recognized as employee of the month 3 times in less than 2 years (team of ~20 engineers)</li>
+```
+
+The remaining two AWS bullets stay.
+
+- [ ] **Step 3: Reload, re-print to PDF, verify single-page fit**
+
+Reload `http://localhost:3000/resume.html`, print to PDF again. Verify the page fits on one letter page. If it still overflows, stop and report back — the spec did not authorize further trimming.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add public/resume.html
+git commit -m "Drop weakest AWS bullet to keep resume on one page"
+```
+
+---
+
+## Task 4: Final verification and cleanup
+
+Goal: do a clean final pass on the rendered resume and stop the dev server.
+
+- [ ] **Step 1: Hard-reload the browser and re-verify the printed PDF**
+
+Hard reload (Cmd+Shift+R on Mac) `http://localhost:3000/resume.html` to bust any cache, then print to PDF one more time. Confirm:
+- One page.
+- Celestia reads as one company with three sub-roles.
+- PR count bullet shows `1,168` and `2,427`.
+- EM bullets are the two tightened versions (no parenthetical on bullet 1).
+- SWE bullet 1 says "consensus-breaking upgrade" and "reused by every subsequent network upgrade".
+- Bullets feel less compressed than before.
+
+- [ ] **Step 2: Spot-check the mobile screen breakpoint**
+
+In the browser, resize the window to ~700px wide (or use DevTools device emulation). Verify the resume page reflows reasonably — no horizontally-clipped sub-role labels, no overlap. The existing `@media (max-width: 900px)` rules in the file should handle this without modification, but a 30-second check is worth it.
+
+- [ ] **Step 3: Stop the dev server**
+
+Stop the background `yarn dev` process.
+
+- [ ] **Step 4: Final status check**
+
+Run:
+```bash
+git status
+git log --oneline -5
+```
+
+Expected: working tree clean, recent commits show the density tweak, Celestia consolidation, and (if applied) the overflow trim.

--- a/docs/superpowers/specs/2026-05-16-resume-density-and-celestia-consolidation-design.md
+++ b/docs/superpowers/specs/2026-05-16-resume-density-and-celestia-consolidation-design.md
@@ -1,0 +1,146 @@
+# Resume: Density and Celestia Consolidation
+
+**Date:** 2026-05-16
+**Target file:** `public/resume.html`
+
+## Goal
+
+Make the printed PDF of the resume feel less visually squished, and reduce content redundancy by consolidating the three separate Celestia role entries into one company block with three sub-roles. Stay on a single letter-size page.
+
+## Scope
+
+Four coordinated changes to `public/resume.html`:
+
+1. **CSS density tweaks** — add vertical breathing room without touching page margins.
+2. **Celestia consolidation** — collapse three `.role` blocks into one block with three italic sub-role labels.
+3. **Refreshed PR counts** — replace the stale `888 / 1,956` figures with live values from GitHub (`1,168 / 2,427`).
+4. **Tightened EM / SWE wording** — sharper, less wordy bullets in the Engineering Manager and Senior Software Engineer entries.
+
+## Non-goals
+
+- Two-page layout, sidebar layout, or any structural restyle (rejected during brainstorming in favor of conservative density tweaks).
+- Adding new sections (Talks, Selected Work, etc.).
+- Quantifying EM / Team Lead bullets with concrete numbers — user opted to tighten wording only.
+- Changes to other roles (AWS, Palantir) beyond the optional overflow-trim escape valve below.
+- Changes to Education, Skills, or the Summary.
+
+## Design
+
+### 1. CSS density tweaks
+
+All values live in the `<style>` block in `public/resume.html`. Page-padding values are untouched — those would shrink content width, which would worsen squish.
+
+| Selector | Property | From | To |
+|---|---|---|---|
+| `.role li` | `margin-bottom` | `3px` | `6px` |
+| `.role li` | `line-height` | `1.5` | `1.55` |
+| `.role li` | `font-size` | `13px` | `13.5px` |
+| `section` | `margin-top` | `22px` | `26px` |
+
+These four changes operate on the dominant repeated elements (bullets and section spacing) and together produce a visible rhythm change on the printed page.
+
+### 2. Celestia consolidation
+
+Three `.role` blocks become one. The single block uses the existing `.role-head` styling for the "Celestia · Jul 2022 — Present" header, and introduces two new classes (`.sub-role`, `.sub-date`) for the italic position labels nested beneath.
+
+**New HTML structure (replaces the three current Celestia `.role` blocks):**
+
+```html
+<div class="role">
+  <div class="role-head">
+    <div class="role-title">
+      <span class="company">Celestia</span>
+    </div>
+    <div class="role-date">Jul 2022 — Present</div>
+  </div>
+
+  <div class="sub-role">Engineering Manager <span class="sub-date">· Mar 2026 — Present</span></div>
+  <ul>
+    <li>Lead an 8-person team owning reliability, performance, and scale for the Celestia protocol</li>
+    <li>Set and drive Q2 OKRs across network reliability, protocol performance, and scale</li>
+  </ul>
+
+  <div class="sub-role">Team Lead <span class="sub-date">· Dec 2025 — Mar 2026</span></div>
+  <ul>
+    <li>Led a 4-person team owning the Celestia consensus layer</li>
+  </ul>
+
+  <div class="sub-role">Senior Software Engineer <span class="sub-date">· Jul 2022 — Dec 2025</span></div>
+  <ul>
+    <li>Led Celestia's first consensus-breaking upgrade (v2.0.0), establishing the framework reused by every subsequent network upgrade</li>
+    <li>Authored 1,168 and reviewed 2,427 merged pull requests across celestia-app and celestia-core</li>
+  </ul>
+</div>
+```
+
+**New CSS (added inside the existing `<style>` block, immediately after the `.role li::before` rule):**
+
+```css
+.sub-role {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 13.5px;
+  color: var(--ink-soft);
+  margin: 10px 0 4px;
+}
+.role .sub-role:first-of-type {
+  margin-top: 6px;
+}
+.sub-role .sub-date {
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 10.5px;
+  color: var(--ink-muted);
+  margin-left: 2px;
+}
+```
+
+Rationale for the styling choices:
+- Italic serif for the position keeps it visually subordinate to the small-caps "Celestia" header but still distinct from the bullets.
+- The mono `.sub-date` matches the existing `.role-date` typography so date columns across the resume share a single visual language.
+- `:first-of-type` reduces the top gap on the first sub-role since it follows the role header directly.
+
+### 3. Refreshed PR counts
+
+Source: live `gh api search/issues` queries against `celestiaorg/celestia-app` and `celestiaorg/celestia-core` (ran 2026-05-16).
+
+| Repo | Authored (merged) | Reviewed (merged) |
+|---|---|---|
+| celestia-app | 1,013 | 2,109 |
+| celestia-core | 155 | 318 |
+| **Combined** | **1,168** | **2,427** |
+
+The SWE bullet uses the combined totals to match the "across celestia-app and celestia-core" framing already in place.
+
+### 4. Tightened EM / SWE wording
+
+| Role | Before | After |
+|---|---|---|
+| EM | Lead an 8-person team (10 reports including two on loan to adjacent team) owning reliability, performance, and scale for the Celestia protocol | Lead an 8-person team owning reliability, performance, and scale for the Celestia protocol |
+| EM | Defined and now drive execution against Q2 OKRs spanning network reliability, protocol performance, and scale targets | Set and drive Q2 OKRs across network reliability, protocol performance, and scale |
+| Team Lead | Led a 4-person team owning the Celestia consensus layer | *(unchanged — already lean)* |
+| SWE | Led the first consensus layer upgrade (v2.0.0), establishing the upgrade framework used by all subsequent network upgrades | Led Celestia's first consensus-breaking upgrade (v2.0.0), establishing the framework reused by every subsequent network upgrade |
+
+## Single-page constraint
+
+The density tweaks add roughly 50–60px of vertical content; the Celestia consolidation reclaims roughly 30–40px (three role-heads collapse to one role-head plus three smaller sub-role labels). Expected net is near-neutral.
+
+**If the page overflows after the changes:** trim the AWS "Recognized as employee of the month 3 times in less than 2 years (team of ~20 engineers)" bullet. It is the weakest bullet in the resume (internal/subjective rather than externally legible) and removing it costs the least signal. This is an escape valve, not a planned change.
+
+## Verification
+
+After implementing, the implementer should:
+
+1. Open `public/resume.html` in a browser at the existing `/resume` route.
+2. Use the toolbar's "Print / Save as PDF" button to render a PDF and confirm:
+   - The resume fits on one letter page.
+   - Bullets and sections feel less compressed than the current version.
+   - The Celestia block visually reads as one company entry with three sub-roles, not three companies.
+3. Verify the PR count bullet shows `1,168` authored and `2,427` reviewed.
+4. Skim for any unintended layout side effects on the screen-viewing breakpoint (`max-width: 900px`).
+
+## Risk
+
+- **Page overflow:** mitigated by the escape valve above.
+- **Sub-role styling drift on the mobile breakpoint:** the existing `@media (max-width: 900px)` block changes `.role-head` to a single column. The new `.sub-role` line is already a single-column flow element, so no media-query work should be needed, but the implementer should confirm on a narrow viewport.
+- **PR-count freshness:** numbers are point-in-time as of 2026-05-16. Future refreshes will require re-running the `gh` queries.

--- a/public/resume.html
+++ b/public/resume.html
@@ -130,31 +130,17 @@
     font-weight: 400;
   }
 
-  .monogram {
-    width: 52px;
-    height: 52px;
-    border: 1.25px solid var(--ink);
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: var(--serif);
-    font-weight: 500;
-    font-size: 20px;
-    letter-spacing: 0.04em;
-    color: var(--ink);
-    flex-shrink: 0;
-  }
 
   .contact {
     display: flex;
-    flex-wrap: wrap;
-    gap: 4px 14px;
+    flex-wrap: nowrap;
+    gap: 4px 12px;
     margin-top: 10px;
     font-family: var(--mono);
     font-size: 10.5px;
     color: var(--ink-soft);
     letter-spacing: 0.01em;
+    white-space: nowrap;
   }
   .contact a {
     color: inherit;
@@ -390,7 +376,8 @@
     }
     .name { font-size: 34px; }
     header { grid-template-columns: 1fr; }
-    .monogram { display: none; }
+
+
     .role-head { grid-template-columns: 1fr; gap: 2px; }
     .bottom-grid { grid-template-columns: 1fr; gap: 18px; }
   }
@@ -422,7 +409,6 @@
           <a href="https://linkedin.com/in/rootulp" target="_blank" rel="noopener">linkedin.com/in/rootulp</a>
         </div>
       </div>
-      <div class="monogram" aria-hidden="true">RP</div>
     </header>
 
     <p class="summary">

--- a/public/resume.html
+++ b/public/resume.html
@@ -271,6 +271,23 @@
     height: 1px;
     background: var(--ink);
   }
+  .sub-role {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 13.5px;
+    color: var(--ink-soft);
+    margin: 10px 0 4px;
+  }
+  .role .sub-role:first-of-type {
+    margin-top: 6px;
+  }
+  .sub-role .sub-date {
+    font-family: var(--mono);
+    font-style: normal;
+    font-size: 10.5px;
+    color: var(--ink-muted);
+    margin-left: 2px;
+  }
   .role li a,
   .summary a {
     color: var(--ink);
@@ -425,43 +442,25 @@
         <div class="role-head">
           <div class="role-title">
             <span class="company">Celestia</span>
-            <span class="sep">—</span>
-            <span class="position">Engineering Manager</span>
           </div>
-          <div class="role-date">Mar 2026 — Present</div>
+          <div class="role-date">Jul 2022 — Present</div>
         </div>
-        <ul>
-          <li>Lead an 8-person team (10 reports including two on loan to adjacent team) owning reliability, performance, and scale for the Celestia protocol</li>
-          <li>Defined and now drive execution against Q2 OKRs spanning network reliability, protocol performance, and scale targets</li>
-        </ul>
-      </div>
 
-      <div class="role">
-        <div class="role-head">
-          <div class="role-title">
-            <span class="company">Celestia</span>
-            <span class="sep">—</span>
-            <span class="position">Team Lead</span>
-          </div>
-          <div class="role-date">Dec 2025 — Mar 2026</div>
-        </div>
+        <div class="sub-role">Engineering Manager <span class="sub-date">· Mar 2026 — Present</span></div>
+        <ul>
+          <li>Lead an 8-person team owning reliability, performance, and scale for the Celestia protocol</li>
+          <li>Set and drive Q2 OKRs across network reliability, protocol performance, and scale</li>
+        </ul>
+
+        <div class="sub-role">Team Lead <span class="sub-date">· Dec 2025 — Mar 2026</span></div>
         <ul>
           <li>Led a 4-person team owning the Celestia consensus layer</li>
         </ul>
-      </div>
 
-      <div class="role">
-        <div class="role-head">
-          <div class="role-title">
-            <span class="company">Celestia</span>
-            <span class="sep">—</span>
-            <span class="position">Senior Software Engineer</span>
-          </div>
-          <div class="role-date">Jul 2022 — Dec 2025</div>
-        </div>
+        <div class="sub-role">Senior Software Engineer <span class="sub-date">· Jul 2022 — Dec 2025</span></div>
         <ul>
-          <li>Led the first consensus layer upgrade (v2.0.0), establishing the upgrade framework used by all subsequent network upgrades</li>
-          <li>Authored 888 and reviewed 1,956 merged pull requests across celestia-app and celestia-core</li>
+          <li>Led Celestia's first consensus-breaking upgrade (v2.0.0), establishing the framework reused by every subsequent network upgrade</li>
+          <li>Authored 1,168 and reviewed 2,427 merged pull requests across celestia-app and celestia-core</li>
         </ul>
       </div>
 

--- a/public/resume.html
+++ b/public/resume.html
@@ -326,19 +326,22 @@
   }
 
   .skills-group {
-    margin-bottom: 12px;
+    margin-bottom: 5px;
+    line-height: 1.5;
   }
   .skills-group:last-child { margin-bottom: 0; }
 
   .skills-label {
+    display: inline;
     font-family: var(--mono);
     font-size: 9.5px;
     text-transform: uppercase;
     letter-spacing: 0.14em;
     color: var(--ink-muted);
-    margin-bottom: 4px;
+    margin-right: 8px;
   }
   .skills-list {
+    display: inline;
     font-family: var(--serif);
     font-size: 13px;
     color: var(--ink);

--- a/public/resume.html
+++ b/public/resume.html
@@ -524,7 +524,7 @@
         <div class="skills-group">
           <div class="skills-label">Domains</div>
           <div class="skills-list">
-            Distributed systems <span class="pipe">·</span> Consensus protocols (Tendermint/CometBFT) <span class="pipe">·</span> Blockchain infrastructure
+            Distributed systems <span class="pipe">·</span> Consensus protocols
           </div>
         </div>
 

--- a/public/resume.html
+++ b/public/resume.html
@@ -183,7 +183,7 @@
 
   /* ---------- Sections ---------- */
   section {
-    margin-top: 22px;
+    margin-top: 26px;
   }
 
   .section-title {
@@ -257,9 +257,9 @@
   .role li {
     position: relative;
     padding-left: 14px;
-    margin-bottom: 3px;
-    font-size: 13px;
-    line-height: 1.5;
+    margin-bottom: 6px;
+    font-size: 13.5px;
+    line-height: 1.55;
     color: var(--ink-soft);
   }
   .role li::before {
@@ -289,7 +289,7 @@
     display: grid;
     grid-template-columns: 1.5fr 1fr;
     gap: 28px;
-    margin-top: 22px;
+    margin-top: 26px;
   }
 
   .edu-school {

--- a/public/resume.html
+++ b/public/resume.html
@@ -104,9 +104,7 @@
   /* ---------- Header ---------- */
   header {
     display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 16px;
-    align-items: end;
+    grid-template-columns: 1fr;
     padding-bottom: 14px;
     border-bottom: 1px solid var(--ink);
   }
@@ -378,7 +376,6 @@
       padding: 32px 24px;
     }
     .name { font-size: 34px; }
-    header { grid-template-columns: 1fr; }
 
 
     .role-head { grid-template-columns: 1fr; gap: 2px; }

--- a/public/resume.html
+++ b/public/resume.html
@@ -473,14 +473,18 @@
         <div class="role-head">
           <div class="role-title">
             <span class="company">Palantir</span>
-            <span class="sep">—</span>
-            <span class="position">Software Engineer</span>
           </div>
           <div class="role-date">Aug 2016 — May 2020</div>
         </div>
+
+        <div class="sub-role">Software Engineer <span class="sub-date">· Aug 2017 — May 2020</span></div>
         <ul>
           <li>Maintained <a href="https://www.palantir.com/docs/foundry/reports/overview" target="_blank" rel="noopener">Foundry Reports</a>, a cross-platform dashboarding application deployed to hundreds of enterprise organizations</li>
           <li>Developed <a href="https://www.palantir.com/docs/foundry/data-connection/overview" target="_blank" rel="noopener">Foundry Data Connection</a> application that connected to external databases and systems to enable automated data pipelines into Foundry</li>
+        </ul>
+
+        <div class="sub-role">Forward Deployed Engineer <span class="sub-date">· Aug 2016 — Aug 2017</span></div>
+        <ul>
           <li>Awarded patents: <a href="https://patents.google.com/patent/US20180330241A1" target="_blank" rel="noopener"><em>Tools for chemical manufacturing</em></a> and <a href="https://patents.google.com/patent/US11769096B2/en" target="_blank" rel="noopener"><em>Automated risk visualization</em></a></li>
         </ul>
       </div>

--- a/public/resume.html
+++ b/public/resume.html
@@ -381,7 +381,7 @@
   }
 
   /* ---------- Responsive (screen viewing) ---------- */
-  @media (max-width: 900px) {
+  @media screen and (max-width: 900px) {
     .frame { padding: 16px 12px 60px; }
     .page {
       width: 100%;

--- a/public/resume.html
+++ b/public/resume.html
@@ -278,7 +278,7 @@
     color: var(--ink-soft);
     margin: 10px 0 4px;
   }
-  .role .sub-role:first-of-type {
+  .role-head + .sub-role {
     margin-top: 6px;
   }
   .sub-role .sub-date {


### PR DESCRIPTION
## Summary
- Density tweaks: more breathing room on bullets (margin/line-height/font-size) and stronger section/bottom-grid separation
- Celestia consolidation: three role entries collapse to one company block with EM/Team Lead/Senior SWE sub-roles; refreshed PR counts to live values (1,168 authored / 2,427 reviewed)
- Palantir consolidation: same sub-role pattern — Software Engineer (2017–2020, Foundry) and Forward Deployed Engineer (2016–2017, patents)
- Tightened EM and SWE bullet wording
- Print bugfixes: scoped responsive `@media` to `screen` so the PDF no longer collapses to mobile layout; fixed dead `:first-of-type` selector
- Header polish: removed RP monogram, forced contact info onto a single row
- Skills polish: inlined group labels, trimmed Domains line

No linked issue (conversational changes captured in \`docs/superpowers/specs/2026-05-16-resume-density-and-celestia-consolidation-design.md\` and \`docs/superpowers/plans/2026-05-16-resume-density-and-celestia-consolidation.md\`).

## Test plan
- [ ] Open \`public/resume.html\` directly in a browser (file:// is fine since the page is fully self-contained).
- [ ] Print / Save as PDF (Letter size) and confirm the resume renders cleanly on 1–2 pages.
- [ ] Verify Education and Skills render side-by-side in the PDF.
- [ ] Verify contact line (location · email · phone · website · LinkedIn) sits on one row.
- [ ] Verify Celestia shows one company header with three sub-roles (EM, Team Lead, Senior SWE) in reverse-chronological order.
- [ ] Verify Palantir shows one company header with two sub-roles (SWE, FDE).
- [ ] Spot-check screen view at narrow width (≤900px) — header collapses, monogram absent, bottom-grid stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)