### PR TITLE
Remove orphan print CSS rules left over from #40

### DIFF
--- a/public/resume.html
+++ b/public/resume.html
@@ -346,7 +346,6 @@
     .name { font-size: 32px; }
     .tagline { font-size: 12px; margin-top: 4px; }
     .contact { font-size: 9.5px; margin-top: 6px; }
-    .monogram { width: 44px; height: 44px; font-size: 17px; }
     .summary { font-size: 12px; line-height: 1.4; margin: 10px 0 2px; }
     section { margin-top: 10px; }
     .section-title { margin: 0 0 7px; padding-bottom: 3px; font-size: 9px; }
@@ -362,7 +361,7 @@
     .edu-degree { font-size: 11.5px; }
     .edu-date { font-size: 9.5px; margin-bottom: 3px; }
     .edu-honors { font-size: 11px; line-height: 1.35; }
-    .skills-label { font-size: 8.5px; margin-bottom: 3px; }
+    .skills-label { font-size: 8.5px; }
     .skills-list { font-size: 11.5px; line-height: 1.35; }
     .skills-group { margin-bottom: 8px; }
     @page {


### PR DESCRIPTION
## Summary
- Drops `.monogram { width: 44px; height: 44px; font-size: 17px }` from `@media print` — the monogram element was removed in #40 so this rule never matches.
- Drops `margin-bottom: 3px` from `.skills-label` inside `@media print` — `.skills-label` is now `display: inline`, so margin-bottom doesn't apply.

Cosmetic only — both rules were dead code. Rendered output is unchanged, so `resume.pdf` doesn't need regeneration.

Follow-up to #40 cleanup notes.

## Test plan
- [ ] `grep monogram public/resume.html` returns nothing.
- [ ] Open `public/resume.html` and verify nothing renders differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)